### PR TITLE
Raise property to verify usb device connection is still available

### DIFF
--- a/UsbSerialForAndroid/driver/CommonUsbSerialPort.cs
+++ b/UsbSerialForAndroid/driver/CommonUsbSerialPort.cs
@@ -47,6 +47,9 @@ namespace Hoho.Android.UsbSerial.Driver
         // non-null when open()
         protected UsbDeviceConnection mConnection = null;
 
+        // check if connection is still available
+        public bool HasConnection => mConnection != null;
+
         protected object mReadBufferLock = new object();
         protected object mWriteBufferLock = new object();
 


### PR DESCRIPTION
If a USB device is disconnected, the Usb Serial Port will still allow you to read/write, but will have null reference errors because the connection is removed.  This allows you to check if the connection is still there and active so you can try to reestablish.