### PR TITLE
Added an optional argument to enable / disable async reads explicitly

### DIFF
--- a/UsbSerialForAndroid/driver/CdcAcmSerialDriver.cs
+++ b/UsbSerialForAndroid/driver/CdcAcmSerialDriver.cs
@@ -46,10 +46,10 @@ namespace Hoho.Android.UsbSerial.Driver
     {
         private static string TAG = typeof(CdcAcmSerialDriver).Name;
 
-        public CdcAcmSerialDriver(UsbDevice device)
+        public CdcAcmSerialDriver(UsbDevice device, bool? enableAsyncReads = null)
         {
             mDevice = device;
-            mPort = new CdcAcmSerialPort(device, 0, this);
+            mPort = new CdcAcmSerialPort(device, 0, this, enableAsyncReads);
         }
 
         class CdcAcmSerialPort : CommonUsbSerialPort
@@ -80,10 +80,17 @@ namespace Hoho.Android.UsbSerial.Driver
             //    mEnableAsyncReads = (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1);
             //}
 
-            public CdcAcmSerialPort(UsbDevice device, int portNumber, IUsbSerialDriver driver) : base(device, portNumber)
+            public CdcAcmSerialPort(UsbDevice device, int portNumber, IUsbSerialDriver driver, bool? enableAsyncReads = null) : base(device, portNumber)
             {
-                mEnableAsyncReads = (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1);
-                //mEnableAsyncReads = false;
+                if (enableAsyncReads != null)
+                {
+                    mEnableAsyncReads = enableAsyncReads.Value;
+                }
+                else
+                {
+                    mEnableAsyncReads = (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1);
+
+                }
                 this.Driver = driver;
             }
 


### PR DESCRIPTION
I observed a garbage collection issue that occurs after reading a large stream of data using this library.

```
[monodroid-gc] 48944 outstanding GREFs. Performing a full GC!
[vicesettingsap] Explicit concurrent copying GC freed 10(32KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 4128KB/8257KB, paused 87us total 24.173ms
[monodroid-gc] GC cleanup summary: 206 objects tested - resurrecting 205.
[monodroid-gc] 48943 outstanding GREFs. Performing a full GC!
[vicesettingsap] Explicit concurrent copying GC freed 3(31KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 4128KB/8257KB, paused 87us total 23.970ms
[monodroid-gc] GC cleanup summary: 205 objects tested - resurrecting 205.
Thread finished: <Thread Pool> #26
The thread 0x1a has exited with code 0 (0x0).
[monodroid-gc] 48944 outstanding GREFs. Performing a full GC!
[vicesettingsap] Explicit concurrent copying GC freed 9(32KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 4128KB/8257KB, paused 91us total 24.563ms
[monodroid-gc] GC cleanup summary: 205 objects tested - resurrecting 205.
[monodroid-gc] 48944 outstanding GREFs. Performing a full GC!
[vicesettingsap] Explicit concurrent copying GC freed 4(32KB) AllocSpace objects, 0(0B) LOS objects, 49% free, 4128KB/8257KB, paused 89us total 24.200ms
[monodroid-gc] GC cleanup summary: 205 objects tested - resurrecting 205.
Thread started: <Thread Pool> #33
```

The root cause appears to be in the way the Java byte object is being allocated. However, it is possible to work around this problem using the sync reads method which does not use the UsbRequest method.

This also significantly improved the USB data throughput in my testing 