### PR TITLE
Set Driver in FtdiSerialDriver.cs

### DIFF
--- a/UsbSerialForAndroid/driver/FtdiSerialDriver.cs
+++ b/UsbSerialForAndroid/driver/FtdiSerialDriver.cs
@@ -59,7 +59,7 @@ namespace Hoho.Android.UsbSerial.Driver
 
             for (int port = 0; port < device.InterfaceCount; port++)
             {
-                mPorts.Add(new FtdiSerialPort(mDevice, port));
+                mPorts.Add(new FtdiSerialPort(mDevice, port, this));
             }
         }
 


### PR DESCRIPTION
Set the driver of the port correctly so that the permission request works. Otherwise, `Driver` would remain null. Verified in the debugger.