### PR TITLE
Databit, stopbit and paraty implemented; Fix CH340 initialization;

### DIFF
--- a/UsbSerialForAndroid/Resources/Resource.Designer.cs
+++ b/UsbSerialForAndroid/Resources/Resource.Designer.cs
@@ -14,7 +14,7 @@ namespace Hoho.Android.UsbSerial
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "12.2.0.155")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.0.0.73")]
 	public partial class Resource
 	{
 		


### PR DESCRIPTION
I was unable to access an Arduino. Finding out she needed to fix these items:

- Fix CH340 Initialization:

https://github.com/mik3y/usb-serial-for-android/commit/2a77ebf8b9d3c651632c3d2d18a2386c0fddb1d3

https://github.com/mik3y/usb-serial-for-android/blob/5bb8db02d5a6f2db32522ce602a6dd7d791de083/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java#L167

- Databit, stopbit and paraty:

https://github.com/mik3y/usb-serial-for-android/blob/5bb8db02d5a6f2db32522ce602a6dd7d791de083/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java#L236

- WriteHandshakeByte -> SetControlLines() 

https://github.com/mik3y/usb-serial-for-android/blob/5bb8db02d5a6f2db32522ce602a6dd7d791de083/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java#L153
