### PR TITLE
Enable STM32SerialDriver:

### DIFF
--- a/UsbSerialForAndroid/driver/STM32SerialDriver.cs
+++ b/UsbSerialForAndroid/driver/STM32SerialDriver.cs
@@ -28,7 +28,21 @@ namespace Hoho.Android.UsbSerial.Driver
 			mPort = new STM32SerialPort(mDevice, 0, this);
 		}
 
-		public class STM32SerialPort : CommonUsbSerialPort
+        public static Dictionary<int, int[]> GetSupportedDevices()
+        {
+            return new Dictionary<int, int[]>
+                {
+                    {
+                        UsbId.VENDOR_STM, new int[]
+                        {
+                            UsbId.STM32_STLINK,
+                            UsbId.STM32_VCOM
+                        }
+                    }
+                };
+        }
+
+        public class STM32SerialPort : CommonUsbSerialPort
 		{
 			readonly string TAG = nameof(STM32SerialDriver);
 
@@ -291,20 +305,6 @@ namespace Hoho.Android.UsbSerial.Driver
 			{
 				int value = (mRts ? 0x2 : 0) | (mDtr ? 0x1 : 0);
 				SendAcmControlMessage(SET_CONTROL_LINE_STATE, value, null);
-			}
-
-			public static Dictionary<int, int[]> GetSupportedDevices()
-			{
-				return new Dictionary<int, int[]>
-				{
-					{
-						UsbId.VENDOR_STM, new int[]
-						{
-							UsbId.STM32_STLINK,
-							UsbId.STM32_VCOM
-						}
-					}
-				};
 			}
 		}
 	}

--- a/UsbSerialForAndroid/driver/UsbSerialProber.cs
+++ b/UsbSerialForAndroid/driver/UsbSerialProber.cs
@@ -46,6 +46,7 @@ namespace Hoho.Android.UsbSerial.Driver
             probeTable.AddDriver(typeof(FtdiSerialDriver));
             probeTable.AddDriver(typeof(ProlificSerialDriver));
             probeTable.AddDriver(typeof(Ch34xSerialDriver));
+            probeTable.AddDriver(typeof(STM32SerialDriver));
             return probeTable;
         }
 


### PR DESCRIPTION
Add STM32SerialDriver in UsbSerialProber.GetDefaultProbeTable()

Bugfix crash (null pointer to GetSupportedDevices()) during adding driver in default probe Table: moving GetSupportedDevices() from STM32SerialDriver.STM32SerialPort to STM32SerialDriver

Successfully tested with Hardware STM32 Virtual Comport.