### PR TITLE
Bugfix in STM32SerialDriver: Read bytes are not returned (wrap does …

### DIFF
--- a/UsbSerialForAndroid/driver/CdcAcmSerialDriver.cs
+++ b/UsbSerialForAndroid/driver/CdcAcmSerialDriver.cs
@@ -68,7 +68,7 @@ namespace Hoho.Android.UsbSerial.Driver
             private static int SET_CONTROL_LINE_STATE = 0x22;
             private static int SEND_BREAK = 0x23;
 
-            private IUsbSerialDriver Driver;
+            private new readonly IUsbSerialDriver Driver;
 
             //public CdcAcmSerialPort(UsbDevice device, int portNumber) : base(device, portNumber)
             //{

--- a/UsbSerialForAndroid/driver/Ch34xSerialDriver.cs
+++ b/UsbSerialForAndroid/driver/Ch34xSerialDriver.cs
@@ -59,7 +59,7 @@ namespace Hoho.Android.UsbSerial.Driver
             private UsbEndpoint mReadEndpoint;
             private UsbEndpoint mWriteEndpoint;
 
-            private IUsbSerialDriver Driver;
+            private new readonly IUsbSerialDriver Driver;
             private string TAG => (Driver as Ch34xSerialDriver)?.TAG;
 
             public Ch340SerialPort(UsbDevice device, int portNumber, IUsbSerialDriver driver) : base(device, portNumber)

--- a/UsbSerialForAndroid/driver/Cp21xxSerialDriver.cs
+++ b/UsbSerialForAndroid/driver/Cp21xxSerialDriver.cs
@@ -86,7 +86,7 @@ namespace Hoho.Android.UsbSerial.Driver
             private UsbEndpoint mReadEndpoint;
             private UsbEndpoint mWriteEndpoint;
 
-            private new IUsbSerialDriver Driver;
+            private readonly new IUsbSerialDriver Driver;
             private string TAG => (Driver as Cp21xxSerialDriver)?.TAG;
 
 

--- a/UsbSerialForAndroid/driver/FtdiSerialDriver.cs
+++ b/UsbSerialForAndroid/driver/FtdiSerialDriver.cs
@@ -103,7 +103,7 @@ namespace Hoho.Android.UsbSerial.Driver
             private Boolean rts = false;
             private int breakConfig = 0;
 
-            private IUsbSerialDriver Driver;
+            private new readonly IUsbSerialDriver Driver;
 
 
             private String TAG = typeof (FtdiSerialDriver).Name;

--- a/UsbSerialForAndroid/driver/ProlificSerialDriver.cs
+++ b/UsbSerialForAndroid/driver/ProlificSerialDriver.cs
@@ -132,7 +132,8 @@ namespace Hoho.Android.UsbSerial.Driver
             Boolean mStopReadStatusThread = false;
             private IOException mReadStatusException = null;
 
-            private IUsbSerialDriver Driver;
+            private new readonly IUsbSerialDriver Driver;
+            
 
             private string TAG => (Driver as ProlificSerialDriver)?.TAG;
 


### PR DESCRIPTION
... does not work in Java.lang.

Additional Treatment of warning CS0108.

Successfully tested with STM32 VCOM.