### PR TITLE
Support Android 14 and fix IOException for Prolific PL2303GT (prodId …

### DIFF
--- a/UsbSerialForAndroid/driver/ProlificSerialDriver.cs
+++ b/UsbSerialForAndroid/driver/ProlificSerialDriver.cs
@@ -374,23 +374,23 @@ namespace Hoho.Android.UsbSerial.Driver
                     {
                         mDeviceType = DeviceType.DEVICE_TYPE_01;
                     }
-                    else if (deviceVersion == 0x300 && usbVersion == 0x200)
+                    else if (usbVersion == 0x200)
                     {
-                        mDeviceType = DeviceType.DEVICE_TYPE_T; // TA
-                    }
-                    else if (deviceVersion == 0x500)
-                    {
-                        mDeviceType = DeviceType.DEVICE_TYPE_T; // TB
-                    }
-                    else if (usbVersion == 0x200 && !TestHxStatus())
-                    {
-                        mDeviceType = DeviceType.DEVICE_TYPE_HXN;
+                        if ((deviceVersion == 0x300 || deviceVersion == 0x500) && TestHxStatus())
+                        {
+                            mDeviceType = DeviceType.DEVICE_TYPE_T; // TA & TB
+                        }
+
+                        else
+                        {
+                            mDeviceType = DeviceType.DEVICE_TYPE_HXN;
+                        }
                     }
                     else
                     {
                         mDeviceType = DeviceType.DEVICE_TYPE_HX;
                     }
-                    
+
                     SetControlLines(mControlLinesValue);
                     ResetDevice();
 


### PR DESCRIPTION
1. [Runtime-registered broadcasts receivers must specify export behavior](https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported) on Android 14.
2. [IOException for Prolific PL2303GT (prodId 9155 / 0x23c3)](https://github.com/anotherlab/UsbSerialForAndroid/issues/57) suggested change works.