### PR TITLE
Fix incorrect hard-coded value for PendingIntentFlags.Mutable

### DIFF
--- a/UsbSerialForAndroid/Extensions/UsbManagerExtensions.cs
+++ b/UsbSerialForAndroid/Extensions/UsbManagerExtensions.cs
@@ -33,7 +33,7 @@ namespace Hoho.Android.UsbSerial.Util
 #if NET6_0_OR_GREATER
             PendingIntentFlags pendingIntentFlags = Build.VERSION.SdkInt >= BuildVersionCodes.S ? PendingIntentFlags.Mutable : 0;
 #else
-            PendingIntentFlags pendingIntentFlags = Build.VERSION.SdkInt >= (BuildVersionCodes)31 ? (PendingIntentFlags).33554432 : 0;
+            PendingIntentFlags pendingIntentFlags = Build.VERSION.SdkInt >= (BuildVersionCodes)31 ? (PendingIntentFlags)33554432 : 0;
 #endif
 
             var intent = PendingIntent.GetBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), pendingIntentFlags);


### PR DESCRIPTION
There was a bug in UsbManagerExtensions.cs when not `NET6_0_OR_GREATER`. Looks like a copy/paste error. 

[Line 36](https://github.com/anotherlab/UsbSerialForAndroid/blob/ebfe4c87ba3ed3f37d8cf9572a1cba3f9760d82f/UsbSerialForAndroid/Extensions/UsbManagerExtensions.cs#L36) is supposed to be equivalent to [Line 34](https://github.com/anotherlab/UsbSerialForAndroid/blob/ebfe4c87ba3ed3f37d8cf9572a1cba3f9760d82f/UsbSerialForAndroid/Extensions/UsbManagerExtensions.cs#L36).

The value `0.33554432` was being cast to the enum type `Android.App.PendingIntentFlags`. It is supposed to be the value `33554432`. 

![image](https://github.com/user-attachments/assets/89206005-f17e-4b25-a4bb-ed7453533eef)
